### PR TITLE
fix: Unmarshal the set value to a json value to avoid stringification of bools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.1-bullseye as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.1-bullseye AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -15,7 +15,7 @@ RUN go build -mod=readonly -v -o helmfile-nix .
 
 FROM --platform=${BUILDPLATFORM:-linux/amd64} nixos/nix:2.22.0 AS nix
 
-RUN nix build --extra-experimental-features nix-command --extra-experimental-features flakes nixpkgs#nixStatic
+RUN nix-build '<nixpkgs>' -A nixStatic
 
 FROM --platform=${BUILDPLATFORM:-linux/amd64} alpine:3.19@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 ARG TARGETOS

--- a/main.go
+++ b/main.go
@@ -269,7 +269,12 @@ func writeValJson(state string, env string, overrides []string) (*os.File, error
 					}
 				}
 			} else {
-				m[kv[0]] = kv[1]
+				var val interface{}
+				err := json.Unmarshal([]byte(kv[1]), &val)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal %s: %s", kv[1], err)
+				}
+				m[kv[0]] = val
 			}
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -59,10 +59,10 @@ func TestTemplate(t *testing.T) {
 	}
 }
 
-var vals = `{"bad":"true","bar":"true","foo":{"bad":"true","bar":"false","baz":true,"foo":true}}`
+var vals = `{"bad":123,"bar":"true","foo":{"bad":"hello","bar":"false","baz":true,"foo":true}}`
 
 func TestWriteValJson(t *testing.T) {
-	f, err := writeValJson(cwd+"/testData/helm", "test", []string{"foo.bar=false", "bad=true", "foo.bad=true"})
+	f, err := writeValJson(cwd+"/testData/helm", "test", []string{"foo.bar=false", "bad=123", "foo.bad=hello"})
 	if err != nil {
 		t.Error("Failed to write values file: ", err)
 	}


### PR DESCRIPTION
```
❯ ./helmfile-nix  -f ../aws-cicd/helm/arc/helmfile.nix render --state-values-set scale_sets_installed=false|grep installed
2024/08/01 19:28:40 Args: [./helmfile-nix render]
2024/08/01 19:28:40 file: dev env: ../aws-cicd/helm/arc/helmfile.nix
2024/08/01 19:28:40 Running nix --extra-experimental-features nix-command --extra-experimental-features flakes eval --json --impure --expr (import /var/folders/bn/5t6p0fy52kl3qg2dr2bqbm440000gp/T/eval.1421950222.nix).render "/Users/marcus/Source/reMarkable/aws-cicd/helm/arc" "dev" "/var/folders/bn/5t6p0fy52kl3qg2dr2bqbm440000gp/T/val.4234348001.json"
      installed: true
      installed: false
      installed: false
      installed: false
```

```

```
