### PR TITLE
fix: nested state values weren't correctly unmarshalled

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -59,7 +59,7 @@ func TestTemplate(t *testing.T) {
 	}
 }
 
-var vals = `{"bad":123,"bar":"true","foo":{"bad":"hello","bar":"false","baz":true,"foo":true}}`
+var vals = `{"bad":123,"bar":"true","foo":{"bad":"hello","bar":false,"baz":true,"foo":true}}`
 
 func TestWriteValJson(t *testing.T) {
 	f, err := writeValJson(cwd+"/testData/helm", "test", []string{"foo.bar=false", "bad=123", "foo.bad=hello"})


### PR DESCRIPTION
Also moves the unmarshal code into a separate function and switches to using the yaml unmarshaller to handle unquoted strings.