### PR TITLE
Fix arm builds

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -36,7 +36,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ steps.lc_repo.outputs.out}}
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.1-bullseye AS builder
+FROM  golang:1.22.1-bullseye AS builder
 
-ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
@@ -13,13 +12,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s
 # Build the binary.
 RUN go build -mod=readonly -v -o helmfile-nix .
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/lix-project/lix:latest  AS nix
+FROM  ghcr.io/lix-project/lix:latest  AS nix
 
 RUN nix-build '<nixpkgs>' -A lixStatic
 RUN chmod 755 result/bin/nix && nix-shell -p gcc --run 'strip result/bin/nix'
 
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} alpine:3.19@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+FROM alpine:3.19@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/eval.nix
+++ b/eval.nix
@@ -33,5 +33,6 @@ rec {
         vals
         mlVals
         ;
+      val = var.values;
     };
 }


### PR DESCRIPTION
Removes the buildplatform bits from the Dockerfile as they were causing arm builds to get x86 binaries. Also bumps the build actions.

On a related note, I think maybe the lc'ing of the artifact name shouldn't be necessary as github claims the metadata action will sanitize the tags automatically? 

https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#repository-name-must-be-lowercase